### PR TITLE
Add a nicely formatted error page

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include kerberosauthenticator *.py
+include kerberosauthenticator/templates/*.html
 
 include LICENSE
 include README.rst

--- a/continuous_integration/before_install.sh
+++ b/continuous_integration/before_install.sh
@@ -6,6 +6,7 @@ container_id="kerberosauthenticator-testing"
 docker run --rm -d \
     -h address.example.com \
     -p 88:88/udp \
+    -p 8888:8888 \
     --name $container_id \
     -v "$git_root":/working \
     jcrist/kerberosauthenticator-testing 

--- a/kerberosauthenticator/tests/test_authenticator.py
+++ b/kerberosauthenticator/tests/test_authenticator.py
@@ -20,6 +20,9 @@ def test_integration(app, auto_login, logged_in):
         resp = yield async_requests.get(url)
         # Sends back 401 requesting authentication
         assert resp.status_code == 401
+        # 401 page is formatted nicely
+        assert "Failed to login with Kerberos." in resp.text
+        assert resp.text.count("/hub/login") >= 2
         # Before that was a redirect to the auth handler
         assert resp.history[0].status_code == 302
         # Now use the redirected url with auth enabled

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
         'jupyterhub',
         'pykerberos;platform_system!="Windows"',
         'winkerberos;platform_system=="Windows"',
-    ]
+    ],
+    include_package_data=True
 )


### PR DESCRIPTION
Adds a nice error page when kerberos authentication fails. Looks like this:

![Screenshot_2019-04-18 JupyterHub](https://user-images.githubusercontent.com/2783717/56376065-9dca1500-61cc-11e9-877d-b023f8b9c178.png)
