### PR TITLE
Add support for Kerberos Local Authenticator

### DIFF
--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -2,3 +2,6 @@ Configuration Options
 =====================
 
 .. autoconfigurable:: kerberosauthenticator.KerberosAuthenticator
+
+.. autoconfigurable:: kerberosauthenticator.KerberosLocalAuthenticator
+

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -4,4 +4,3 @@ Configuration Options
 .. autoconfigurable:: kerberosauthenticator.KerberosAuthenticator
 
 .. autoconfigurable:: kerberosauthenticator.KerberosLocalAuthenticator
-

--- a/kerberosauthenticator/__init__.py
+++ b/kerberosauthenticator/__init__.py
@@ -1,4 +1,4 @@
-from .auth import KerberosAuthenticator
+from .auth import KerberosAuthenticator, KerberosLocalAuthenticator
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/kerberosauthenticator/auth.py
+++ b/kerberosauthenticator/auth.py
@@ -2,7 +2,7 @@ import os
 
 import kerberos
 from jinja2 import ChoiceLoader, FileSystemLoader
-from jupyterhub.auth import Authenticator
+from jupyterhub.auth import Authenticator, LocalAuthenticator
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import url_path_join
 from tornado import web
@@ -136,3 +136,12 @@ class KerberosAuthenticator(Authenticator):
         finally:
             if gss_context is not None:
                 kerberos.authGSSServerClean(gss_context)
+
+
+class KerberosLocalAuthenticator(LocalAuthenticator, KerberosAuthenticator):
+    """
+    Kerberos local authenticator for JupyterHub
+
+    Checks for local users, and can attempt to create them if they exist.
+    """
+    pass


### PR DESCRIPTION
Supports creating local system user accounts on login to a jupyterhub server. (In a similar fix to: https://github.com/jupyterhub/ldapauthenticator/pull/36, for LDAPAuthenticator.)

Closes #5 

To use the feature, these options are added/changed in the `jupyterhub_config.py` file:

```python
c.JupyterHub.authenticator_class = 'kerberosauthenticator.KerberosLocalAuthenticator'
c.LocalAuthenticator.create_system_users = True
```
