### PR TITLE
Update test fixtures for new JupyterHub

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -9,7 +9,7 @@ conda install -c conda-forge \
     notebook \
     requests-kerberos
 
-pip install pytest-tornado
+pip install pytest-asyncio
 
 cd /working
 

--- a/kerberosauthenticator/tests/test_authenticator.py
+++ b/kerberosauthenticator/tests/test_authenticator.py
@@ -7,9 +7,9 @@ from jupyterhub.tests.utils import async_requests
 from requests_kerberos import HTTPKerberosAuth
 
 
-@pytest.mark.gen_test(timeout=60)
+@pytest.mark.asyncio
 @pytest.mark.parametrize('auto_login', [True, False])
-def test_integration(app, auto_login, logged_in):
+async def test_integration(app, auto_login, logged_in):
     app.authenticator.auto_login = auto_login
 
     # Create a user
@@ -17,7 +17,7 @@ def test_integration(app, auto_login, logged_in):
 
     if auto_login:
         url = public_url(app, path="/hub/login")
-        resp = yield async_requests.get(url)
+        resp = await async_requests.get(url)
         # Sends back 401 requesting authentication
         assert resp.status_code == 401
         # 401 page is formatted nicely
@@ -33,7 +33,7 @@ def test_integration(app, auto_login, logged_in):
         url = public_url(app, path="/hub/kerberos_login")
 
     # Go through the login procedure
-    resp = yield async_requests.get(
+    resp = await async_requests.get(
         url,
         auth=HTTPKerberosAuth(hostname_override="address.example.com")
     )


### PR DESCRIPTION
The new release of JupyterHub broke our test fixtures (but not our
actual functionality). Update the tests to pass again.