### PR TITLE
Fixes for modern JupyterHub and Python versions

### DIFF
--- a/kerberosauthenticator/auth.py
+++ b/kerberosauthenticator/auth.py
@@ -22,17 +22,16 @@ class KerberosLoginHandler(BaseHandler):
 
         self.log.debug('Adding %s to template path', TEMPLATE_DIR)
         loader = FileSystemLoader([TEMPLATE_DIR])
-        env = self.settings['jinja2_env_sync']
+        env = self.settings['jinja2_env']
         previous_loader = env.loader
         env.loader = ChoiceLoader([previous_loader, loader])
         self._loaded = True
 
-    def raise_auth_required(self):
+    async def raise_auth_required(self):
         self.set_status(401)
-        data = self.render_template(
+        data = await self.render_template(
             'kerberos_login_error.html',
             login_url=self.settings['login_url'],
-            sync=True
         )
         self.write(data)
         self.set_header("WWW-Authenticate", "Negotiate")
@@ -41,11 +40,11 @@ class KerberosLoginHandler(BaseHandler):
     async def get(self):
         auth_header = self.request.headers.get('Authorization')
         if not auth_header:
-            self.raise_auth_required()
+            await self.raise_auth_required()
 
         auth_type, auth_key = auth_header.split(" ", 1)
         if auth_type != 'Negotiate':
-            self.raise_auth_required()
+            await self.raise_auth_required()
 
         # Headers are of the proper form, initialize login routine
         user = await self.login_user()

--- a/kerberosauthenticator/auth.py
+++ b/kerberosauthenticator/auth.py
@@ -22,7 +22,7 @@ class KerberosLoginHandler(BaseHandler):
 
         self.log.debug('Adding %s to template path', TEMPLATE_DIR)
         loader = FileSystemLoader([TEMPLATE_DIR])
-        env = self.settings['jinja2_env']
+        env = self.settings['jinja2_env_sync']
         previous_loader = env.loader
         env.loader = ChoiceLoader([previous_loader, loader])
         self._loaded = True
@@ -31,7 +31,8 @@ class KerberosLoginHandler(BaseHandler):
         self.set_status(401)
         data = self.render_template(
             'kerberos_login_error.html',
-            login_url=self.settings['login_url']
+            login_url=self.settings['login_url'],
+            sync=True
         )
         self.write(data)
         self.set_header("WWW-Authenticate", "Negotiate")

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
A couple of quick fixes

- Force sync jinja, taken from https://discourse.jupyter.org/t/kerberos-authenticator-sso-not-working/38337/4
- Update versioneer.py to work with modern Python versions, though we could also remove this file and use setuptools-scm
